### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/sas-grid.template
+++ b/templates/sas-grid.template
@@ -596,7 +596,7 @@
                         "Fn::Sub": "var response = require('cfn-response');\nexports.handler = function(event, context) {\n  var result = parseInt(event.ResourceProperties.Op1) / parseInt(event.ResourceProperties.Op2);\n result = Math.round(result);\n response.send(event, context, response.SUCCESS, {Value: result});\n};\n"
                     }
                 },
-                "Runtime": "nodejs8.10"
+                "Runtime": "nodejs10.x"
             },
             "Condition": "RunGPFSStack"
         },


### PR DESCRIPTION
CloudFormation templates in quickstart-sas-grid have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.